### PR TITLE
Add winetricks as a dependancy

### DIFF
--- a/com.valvesoftware.Steam.Utility.steamtinkerlaunch.yml
+++ b/com.valvesoftware.Steam.Utility.steamtinkerlaunch.yml
@@ -50,6 +50,16 @@ modules:
         commands: [ "autoreconf -fi" ]
         dest-filename: "autogen.sh"
 
+  - name: winetricks
+    buildsystem: simple
+    build-commands:
+    - install -Dm755 -t "${FLATPAK_DEST}/bin" src/winetricks
+    sources:
+      - type: archive
+        url: https://github.com/Winetricks/winetricks/archive/refs/tags/20220411.tar.gz
+        sha256: c16e09ee4e5fda48a49ae9515a9c6d175713792be1b85ea92624d93e37effbd0
+
+
   - name: xdotool
     no-autogen: true
     make-args:


### PR DESCRIPTION
Used `install src/winetricks` instead of using `make install` because we only need the actual script, not any of the extras like the icon and `.desktop` file.

Also, for some odd reason when I used the following I was getting weird errors about `/app/bin/` not being writeable... :confused: 

```yaml
  - name: winetricks
    buildsystem: autotools
    no-autogen: true
    make-install-args:
      - 'PREFIX=${FLATPAK_DEST}'
    post-install:
      - chmod +x /app/bin/winetricks
```

Probably better to just have the simple `install` one-liner anyway, for our purposes.

In theory, this should remove the need for https://github.com/frostworx/steamtinkerlaunch/commit/d16b76c45fe77f0b64b19b041be08becd1ae45ee since winetricks will be on the `PATH`