### PR TITLE
Add rsync as a dependancy

### DIFF
--- a/com.valvesoftware.Steam.Utility.steamtinkerlaunch.yml
+++ b/com.valvesoftware.Steam.Utility.steamtinkerlaunch.yml
@@ -28,6 +28,7 @@ modules:
   - modules/innoextract.yml
   - modules/jq.yml
   - modules/pev.yml
+  - modules/rsync.yml
   - modules/xdotool.yml
   - modules/xprop.yml
   - modules/xxd.yml

--- a/modules/rsync.yml
+++ b/modules/rsync.yml
@@ -1,0 +1,21 @@
+---
+name: rsync
+no-autogen: true
+config-opts:
+  - "--prefix=${FLATPAK_DEST}"
+  - "--with-included-popt"
+  - "--with-included-zlib"
+  - "--disable-xxhash" # Couldn't meet the dependancy
+
+sources:
+  - type: archive
+    url: https://download.samba.org/pub/rsync/src/rsync-3.2.4.tar.gz
+    sha256: 6f761838d08052b0b6579cf7f6737d93e47f01f4da04c5d24d3447b7f2a5fad1
+    x-checker-data:
+      type: anitya
+      project-id: 4217
+      stable-only: true
+      url-template: https://download.samba.org/pub/rsync/src/rsync-$version.tar.gz
+  
+cleanup:
+  - /share/man


### PR DESCRIPTION
You mentioned in [this comment](https://github.com/frostworx/steamtinkerlaunch/issues/27#issuecomment-1152654164) that you were struggling to add rsync. You mentioned python being an issue, so [it sounds like](https://github.com/WayneD/rsync/blob/master/INSTALL.md#autoconf--manpages) you were trying to build from git rather than building a release version. The source releases include additional pre-generated files (that you would otherwise need python to generate).

IMO it's generally better to use stable releases rather than latest git commits when it comes to package dependencies, anyway.

I've included [anitya](https://release-monitoring.org/project/4217/) support. I think this makes flathubbot open PRs automatically when rsync release new versions.

I've disabled `xxhash` since I didn't want to spend time pulling in additional dependencies. If you want to look into it, [here's the anitya page](https://release-monitoring.org/project/17583/) and [here's the upstream github](https://github.com/Cyan4973/xxHash/).

I also noticed that rsync's `./configure` automatically detects the `nouser` user and group IDs. I assume this shouldn't cause an issue with IDs being different in the flatpak sandbox? I believe it's possible to [manually set them](https://github.com/WayneD/rsync/blob/master/INSTALL.md#build-and-install) if necessary.

```
[📦 com.valvesoftware.Steam ~]$ which rsync
/app/utils/bin/rsync
[📦 com.valvesoftware.Steam ~]$ rsync --version
rsync  version 3.2.4  protocol version 31
Copyright (C) 1996-2022 by Andrew Tridgell, Wayne Davison, and others.
Web site: https://rsync.samba.org/
Capabilities:
    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
    xattrs, optional protect-args, iconv, prealloc, stop-at, no crtimes
Optimizations:
    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
Checksum list:
    md5 md4 none
Compress list:
    zstd lz4 zlibx zlib none

rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
are welcome to redistribute it under certain conditions.  See the GNU
General Public Licence for details.
```